### PR TITLE
Improve logging

### DIFF
--- a/CameraAccessory.js
+++ b/CameraAccessory.js
@@ -15,7 +15,7 @@ module.exports = (hap, Accessory, log) => class CameraAccessory extends Accessor
     .setCharacteristic(hap.Characteristic.SerialNumber, '42')
     .setCharacteristic(hap.Characteristic.FirmwareRevision, packageJSON.version)
     this.on('identify', function (paired, callback) { log('**identify**'); callback() })
-    const cameraSource = new CameraSource(hap, conf)
+    const cameraSource = new CameraSource(hap, conf, log)
     this.configureCameraSource(cameraSource)
   }
 }

--- a/CameraSource.js
+++ b/CameraSource.js
@@ -6,9 +6,10 @@ var crypto = require('crypto')
 
 module.exports = Camera
 
-function Camera (hap, conf) {
+function Camera (hap, conf, log) {
   this.hap = hap
   this.conf = conf
+  this.log = log
   this.services = []
   this.streamControllers = []
   this.debug = conf.debug === true
@@ -65,15 +66,29 @@ Camera.prototype.handleSnapshotRequest = function (request, callback) {
 -f video4linux2 -input_format mjpeg -video_size ${request.width}x${request.height} -i /dev/video0 \
 -vframes 1 -f mjpeg -`
   if (this.debug) {
-    console.log(ffmpegCommand)
+    console.log('ffmpeg', ffmpegCommand)
   }
   let ffmpeg = spawn('ffmpeg', ffmpegCommand.split(' '), {env: process.env})
+  let self = this
   var imageBuffer = Buffer.alloc(0)
   ffmpeg.stdout.on('data', function (data) { imageBuffer = Buffer.concat([imageBuffer, data]) })
   if (this.debug) {
-    ffmpeg.stderr.on('data', function (data) { console.log('ffmpeg', String(data)) })
+    ffmpeg.stderr.on('data', function (data) { console.log(String(data)) })
   }
-  ffmpeg.on('close', function (code) { callback(null, imageBuffer) })
+  ffmpeg.on('error', function(error) {
+    self.log('Failed to take a snapshot')
+    if (self.debug) {
+      console.log('Error:', error.message)
+    }
+  })
+  ffmpeg.on('close', function (code) {
+    if (!code || code === 255) {
+      self.log(`Took snapshot at ${request.width}x${request.height}`)
+      callback(null, imageBuffer)
+    } else {
+      self.log(`ffmpeg exited with code ${code}`)
+    }
+  })
 }
 
 Camera.prototype.handleCloseConnection = function (connectionID) {
@@ -187,18 +202,35 @@ Camera.prototype.handleStreamRequest = function (request) {
     let port = this.pendingSessions[sessionIdentifier]['video_port']
     let ssrc = this.pendingSessions[sessionIdentifier]['video_ssrc']
 
+    this.log(`Starting video stream (${width}x${height}, ${fps} fps, ${bitrate} kbps)`)
+    let self = this
     let ffmpegCommand = `\
 -f video4linux2 -input_format h264 -video_size ${width}x${height} -framerate ${fps} -i /dev/video0 \
 -vcodec copy -an -payload_type 99 -ssrc ${ssrc} -f rtp \
 -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params ${srtp} \
 srtp://${address}:${port}?rtcpport=${port}&localrtcpport=${port}&pkt_size=1378`
     if (this.debug) {
-      console.log(ffmpegCommand)
+      console.log('ffmpeg', ffmpegCommand)
     }
     let ffmpeg = spawn('ffmpeg', ffmpegCommand.split(' '), {env: process.env})
-    if (this.debug) {
-      ffmpeg.stderr.on('data', function (data) { console.log('ffmpeg', String(data)) })
-    }
+    ffmpeg.stderr.on('data', function (data) {
+      if (self.debug) {
+        console.log(String(data))
+      }
+    })
+    ffmpeg.on('error', function(error) {
+      self.log('Failed to start video stream')
+      if (self.debug) {
+        console.log('Error:', error.message)
+      }
+    })
+    ffmpeg.on('close', function(code) {
+      if (!code || code === 255) {
+        self.log('Video stream stopped')
+      } else {
+        self.log(`ffmpeg exited with code ${code}`)
+      }
+    })
     this.ongoingSessions[sessionIdentifier] = ffmpeg
 
     delete this.pendingSessions[sessionIdentifier]
@@ -231,13 +263,19 @@ Camera.prototype._createStreamControllers = function (maxStreams, options) {
 }
 
 Camera.prototype._v4l2CTLSetCTRL = function (name, value) {
+  let self = this
   let v4l2ctlCommand = `--set-ctrl ${name}=${value}`
   if (this.debug) {
-    console.log(v4l2ctlCommand)
+    console.log('v4l2-ctl', v4l2ctlCommand)
   }
   let v4l2ctl = spawn('v4l2-ctl', v4l2ctlCommand.split(' '), {env: process.env})
-  v4l2ctl.on('error', function (err) { console.log(`error while setting ${name}: ${err.message}`) })
+  v4l2ctl.on('error', function (err) {
+    self.log(`Failed to set '${name}' to '${value}'`)
+    if (self.debug) {
+      console.log('Error:', err.message)
+    }
+  })
   if (this.debug) {
-    v4l2ctl.stderr.on('data', function (data) { console.log('v4l2-ctl', String(data)) })
+    v4l2ctl.stderr.on('data', function (data) { console.log(String(data)) })
   }
 }

--- a/CameraSource.js
+++ b/CameraSource.js
@@ -69,24 +69,23 @@ Camera.prototype.handleSnapshotRequest = function (request, callback) {
     console.log('ffmpeg', ffmpegCommand)
   }
   let ffmpeg = spawn('ffmpeg', ffmpegCommand.split(' '), {env: process.env})
-  let self = this
   var imageBuffer = Buffer.alloc(0)
   ffmpeg.stdout.on('data', function (data) { imageBuffer = Buffer.concat([imageBuffer, data]) })
   if (this.debug) {
     ffmpeg.stderr.on('data', function (data) { console.log(String(data)) })
   }
-  ffmpeg.on('error', function(error) {
-    self.log('Failed to take a snapshot')
-    if (self.debug) {
+  ffmpeg.on('error', error => {
+    this.log('Failed to take a snapshot')
+    if (this.debug) {
       console.log('Error:', error.message)
     }
   })
-  ffmpeg.on('close', function (code) {
+  ffmpeg.on('close', code => {
     if (!code || code === 255) {
-      self.log(`Took snapshot at ${request.width}x${request.height}`)
+      this.log(`Took snapshot at ${request.width}x${request.height}`)
       callback(null, imageBuffer)
     } else {
-      self.log(`ffmpeg exited with code ${code}`)
+      this.log(`ffmpeg exited with code ${code}`)
     }
   })
 }
@@ -203,7 +202,6 @@ Camera.prototype.handleStreamRequest = function (request) {
     let ssrc = this.pendingSessions[sessionIdentifier]['video_ssrc']
 
     this.log(`Starting video stream (${width}x${height}, ${fps} fps, ${bitrate} kbps)`)
-    let self = this
     let ffmpegCommand = `\
 -f video4linux2 -input_format h264 -video_size ${width}x${height} -framerate ${fps} -i /dev/video0 \
 -vcodec copy -an -payload_type 99 -ssrc ${ssrc} -f rtp \
@@ -213,22 +211,22 @@ srtp://${address}:${port}?rtcpport=${port}&localrtcpport=${port}&pkt_size=1378`
       console.log('ffmpeg', ffmpegCommand)
     }
     let ffmpeg = spawn('ffmpeg', ffmpegCommand.split(' '), {env: process.env})
-    ffmpeg.stderr.on('data', function (data) {
-      if (self.debug) {
+    ffmpeg.stderr.on('data', data => {
+      if (this.debug) {
         console.log(String(data))
       }
     })
-    ffmpeg.on('error', function(error) {
-      self.log('Failed to start video stream')
-      if (self.debug) {
+    ffmpeg.on('error', error => {
+      this.log('Failed to start video stream')
+      if (this.debug) {
         console.log('Error:', error.message)
       }
     })
-    ffmpeg.on('close', function(code) {
+    ffmpeg.on('close', code => {
       if (!code || code === 255) {
-        self.log('Video stream stopped')
+        this.log('Video stream stopped')
       } else {
-        self.log(`ffmpeg exited with code ${code}`)
+        this.log(`ffmpeg exited with code ${code}`)
       }
     })
     this.ongoingSessions[sessionIdentifier] = ffmpeg
@@ -263,15 +261,14 @@ Camera.prototype._createStreamControllers = function (maxStreams, options) {
 }
 
 Camera.prototype._v4l2CTLSetCTRL = function (name, value) {
-  let self = this
   let v4l2ctlCommand = `--set-ctrl ${name}=${value}`
   if (this.debug) {
     console.log('v4l2-ctl', v4l2ctlCommand)
   }
   let v4l2ctl = spawn('v4l2-ctl', v4l2ctlCommand.split(' '), {env: process.env})
-  v4l2ctl.on('error', function (err) {
-    self.log(`Failed to set '${name}' to '${value}'`)
-    if (self.debug) {
+  v4l2ctl.on('error', err => {
+    this.log(`Failed to set '${name}' to '${value}'`)
+    if (this.debug) {
       console.log('Error:', err.message)
     }
   })

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ sudo systemctl start hap-camera-rpi
   "id": "Pi Camera",
   "rotate": 0,
   "verticalFlip": false,
-  "horizontalFlip": false
+  "horizontalFlip": false,
+  "debug": false
 }
 ```
 


### PR DESCRIPTION
This plugin is working great for me on my RPi, but unfortunately it makes the homebridge log quite hard to read with all the output from ffmpeg. So in this PR I've improved the logging by suppressing the output from ffmpeg (unless `debug` is set to `true` in the config) and instead printing some more friendly messages like `"Starting video stream (1280x720, 30 fps, 299 kbps)"` and `"Video stream stopped"`.