### PR TITLE
Fixes Warning Log

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,5 +20,5 @@ Platform.prototype.configureAccessory = function (accessory) {}
 Platform.prototype.didFinishLaunching = function () {
   if (!this.config.cameras) return
   const configuredAccessories = this.config.cameras.map(conf => new this.CameraAccessory(conf))
-  this.api.publishCameraAccessories('rpi-camera', configuredAccessories)
+  this.api.publishCameraAccessories('homebridge-rpi-camera', configuredAccessories)
 }

--- a/index.js
+++ b/index.js
@@ -20,5 +20,5 @@ Platform.prototype.configureAccessory = function (accessory) {}
 Platform.prototype.didFinishLaunching = function () {
   if (!this.config.cameras) return
   const configuredAccessories = this.config.cameras.map(conf => new this.CameraAccessory(conf))
-  this.api.publishCameraAccessories('homebridge-rpi-camera', configuredAccessories)
+  this.api.publishCameraAccessories('homebridge-camera-rpi', configuredAccessories)
 }


### PR DESCRIPTION
@moritzmhmk, This was posted on [reddit](https://www.reddit.com/r/homebridge/comments/gnf1jd/was_checking_my_logs_and_saw_an_interesting_log/).

```
[rpi-camera] Initializing rpi-camera platform...
One of your plugins incorrectly registered an external accessory using the platform name (rpi-camera) and not the plugin identifier. Please report this to the developer!
```